### PR TITLE
Pause the transaction

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -157,7 +157,10 @@ module Appsignal
 
     # @api private
     def complete
-      discard! if !error? && (rand > SAMPLING_RATE)
+      if !has_error? && (rand > SAMPLING_RATE)
+        pause!
+        discard!
+      end
 
       if discarded?
         Appsignal.internal_logger.debug "Skipping transaction '#{transaction_id}' " \

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -157,7 +157,7 @@ module Appsignal
 
     # @api private
     def complete
-      if !has_error? && (rand > SAMPLING_RATE)
+      if !error? && (rand > SAMPLING_RATE)
         pause!
         discard!
       end

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Appsignal
-  VERSION = "4.2.0"
+  VERSION = "4.2.2"
 end

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Appsignal
-  VERSION = "4.2.2"
+  VERSION = "4.2.0"
 end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -181,6 +181,7 @@ describe Appsignal::Transaction do
             transaction.add_tags(:foo => "bar")
             transaction.complete
             expect(transaction).to be_completed
+            expect(transaction).not_to be_paused
             expect(transaction).not_to be_discarded
           end
         end
@@ -194,6 +195,7 @@ describe Appsignal::Transaction do
             transaction.add_tags(:foo => "bar")
             transaction.complete
             expect(transaction).not_to be_completed
+            expect(transaction).to be_paused
             expect(transaction).to be_discarded
           end
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -208,6 +208,7 @@ describe Appsignal::Transaction do
               transaction.add_tags(:foo => "bar")
               transaction.complete
               expect(transaction).to be_completed
+              expect(transaction).not_to be_paused
               expect(transaction).not_to be_discarded
             end
           end
@@ -227,6 +228,7 @@ describe Appsignal::Transaction do
           transaction.add_tags(:foo => "bar")
           transaction.complete
           expect(transaction).to be_completed
+          expect(transaction).not_to be_paused
           expect(transaction).not_to be_discarded
         end
       end
@@ -244,6 +246,7 @@ describe Appsignal::Transaction do
           transaction.add_tags(:foo => "bar")
           transaction.complete
           expect(transaction).not_to be_completed
+          expect(transaction).to be_paused
           expect(transaction).to be_discarded
         end
       end


### PR DESCRIPTION
This solves the error "appsignal: Nothing on timestack in finish event for event".

Since the transaction was also not paused, it tried to [finish the event](https://github.com/renuo/appsignal-ruby/blob/acb8eeec81785f6846467da46227da0ab67998c3/lib/appsignal/transaction.rb#L559)

By pausing the transaction it will not try to finish it.